### PR TITLE
默认友链无法访问

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ $active-color = #93a3b3
       // 友链按钮名
       "name": "Hiiro按钮",
       // 友链地址
-      "url": "https: //hiiro.club/",
+      "url": "https://hiiro.club/",
       // 友链按钮颜色
       "background": "#F5C1BB",
       // 友链按钮文字颜色

--- a/setting/setting.json
+++ b/setting/setting.json
@@ -22,12 +22,12 @@
   "link": [
     {
       "name": "Hiiro按钮",
-      "url": "https: //hiiro.club/",
+      "url": "https://hiiro.club/",
       "background": "#F5C1BB"
     },
     {
       "name": "七奈按钮",
-      "url": "https: //kaguranana.moe/",
+      "url": "https://kaguranana.moe/",
       "background": "#c4afd0"
     }
   ],


### PR DESCRIPTION
链接中多打了一个空格，会访问成https://%20//hiiro.club/